### PR TITLE
seedmtk: introduce nokernel for hack in make

### DIFF
--- a/nokernel/Android.mk
+++ b/nokernel/Android.mk
@@ -1,0 +1,9 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := nokernel
+
+#Hack for prebuilt kernel
+$(shell mkdir -p $(OUT)/obj/KERNEL_OBJ/usr)
+$(shell touch $(OUT)/obj/KERNEL_OBJ/usr/export_includes)


### PR DESCRIPTION
Before the prebuilt kernel binary hack was performed during lunch.
Now let's create a separate module for the kernel hack, so it gets performed while make is including the Makefile to ensure that it is available during the actual build.

In that way you don't have to lunch again after performing `make clean`
